### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/h8mail/utils/classes.py
+++ b/h8mail/utils/classes.py
@@ -224,7 +224,7 @@ class target:
             for record in search["records"]:
                 filename = record["systemid"].strip() + ".txt"
                 intel_files.append(filename)
-                if record["media"] is not 24:
+                if record["media"] != 24:
                     c.info_news(
                         "Skipping {name}, not text ({type})".format(
                             type=record["mediah"], name=record["name"]
@@ -419,7 +419,7 @@ class target:
                         self.data.append(("SCYLLA_USERNAME", k))
                         self.pwned += 1
                     elif (
-                        "Email" in field and k is not None and user_query is not "email"
+                        "Email" in field and k is not None and user_query != "email"
                     ):
                         self.data.append(("SCYLLA_EMAIL", k))
                         self.pwned += 1


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> 0 is 0
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```