### PR TITLE
Fix path given to -j and -o arguments

### DIFF
--- a/h8mail/utils/helpers.py
+++ b/h8mail/utils/helpers.py
@@ -153,7 +153,7 @@ def save_results_csv(dest_csv, target_obj_list):
     Outputs CSV from target object list.
     Dumps the target.data object variable into CSV file.
     """
-    with open(dest_csv, "w", newline="") as csvfile:
+    with open(os.path.expanduser(dest_csv), "w", newline="") as csvfile:
         try:
             writer = csv.writer(csvfile)
 

--- a/h8mail/utils/print_json.py
+++ b/h8mail/utils/print_json.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .colors import colors as c
 import json
+import os
 
 def generate_source_arrays(pwned_data):
     data_array = []
@@ -30,5 +31,5 @@ def save_results_json(dest_json, target_obj_list):
         current_target["data"] = generate_source_arrays(t.data)
         data['targets'].append(current_target)
     
-    with open(dest_json, 'w') as outfile:
+    with open(os.path.expanduser(dest_json), 'w') as outfile:
         json.dump(data, outfile)


### PR DESCRIPTION
Prior to this modification, you can't specify path like " ~/foo.json" for example.