### PR TITLE
added reset of breachcomp_path variable

### DIFF
--- a/h8mail/utils/breachcompilation.py
+++ b/h8mail/utils/breachcompilation.py
@@ -35,8 +35,9 @@ def clean_targets(targets):
     return targets
 
 def breachcomp_check(targets, breachcomp_path):
-    breachcomp_path =  os.path.join(breachcomp_path, "data")
+    rst_breachcomp_path =  os.path.join(breachcomp_path, "data")
     for t in targets:
+        breachcomp_path = rst_breachcomp_path
         if len(t.target):
             for i in range(len(t.target)):
                 if t.target[i].isalnum():


### PR DESCRIPTION
#156 fix the search when using `-bc` option by resetting the `breachcomp_path` variable.
In the original script after the first loop the path is broken
