### PR TITLE
Add LeakCheck service

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@
 | [scylla.so](https://scylla.so/) - Service (free) | Cleartext passwords, hashs and salts, usernames, IPs, domain | :construction: |
 | [Dehashed.com](https://dehashed.com/) - Service | Cleartext passwords, hashs and salts, usernames, IPs, domain | :white_check_mark: :key: |
 | [IntelX.io](https://intelx.io/signup) - Service (free trial) | Cleartext passwords, hashs and salts, usernames, IPs, domain, Bitcoin Wallets, IBAN | :white_check_mark: :key: |
-| :new: [Breachdirectory.org](https://breachdirectory.org) - Service (free) | Cleartext passwords, hashs and salts, usernames, domain | :construction: :key: |
+| [Breachdirectory.org](https://breachdirectory.org) - Service (free) | Cleartext passwords, hashs and salts, usernames, domain | :construction: :key: |
+| :new: [LeakCheck.io](https://leakcheck.io/?from=h8mail) - Public | List of data breaches by e-mail or username and compromised fields | :white_check_mark: |
+| :new: [LeakCheck.io](https://leakcheck.io/?from=h8mail) - Service | Cleartext passwords, e-mails, usernames, ZIPs, IPs, full names, phones, stealer logs | :white_check_mark: :key: |
 
 *:key: - API key required*  
 

--- a/h8mail/utils/gen_config.py
+++ b/h8mail/utils/gen_config.py
@@ -24,6 +24,7 @@ def gen_config_file():
 ;intelx_maxfile = 10
 ;breachdirectory_user = 
 ;breachdirectory_pass =
+;leakcheck_apikey =
 """
         dest_config.write(config)
         c.good_news(

--- a/h8mail/utils/print_results.py
+++ b/h8mail/utils/print_results.py
@@ -49,6 +49,8 @@ def print_results(results, hide=False):
                     c.print_result(t.target, t.data[i][1], t.data[i][0])
                 if "WLI" in t.data[i][0]:
                     c.print_result(t.target, t.data[i][1], t.data[i][0])
+                if "LC" in t.data[i][0]:
+                    c.print_result(t.target, t.data[i][1], t.data[i][0])
                 if "SCYLLA" in t.data[i][0]:
                     c.print_result(t.target, t.data[i][1], t.data[i][0])
                 if "DHASHD" in t.data[i][0]:

--- a/h8mail/utils/run.py
+++ b/h8mail/utils/run.py
@@ -8,7 +8,7 @@ import time
 import sys
 
 from .breachcompilation import breachcomp_check
-from .classes import target
+from .classes import target, LC_SUPPORTED
 from .colors import colors as c
 from .helpers import (
     fetch_emails,
@@ -64,6 +64,7 @@ def target_factory(targets, user_args):
             current_target = target(t)
         if not skip_default_queries:
             if not user_args.skip_defaults:
+                current_target.get_leakcheck_pub()
                 current_target.get_hunterio_public()
                 ## emailrep seems to insta-block h8mail user agent without a key
                 # if api_keys is None or "emailrep" not in api_keys:
@@ -83,6 +84,8 @@ def target_factory(targets, user_args):
                 )
             if "hibp" in api_keys and query == "email":
                 current_target.get_hibp3(api_keys["hibp"])
+            if "leakcheck_apikey" in api_keys and query in LC_SUPPORTED:
+                current_target.get_leakcheck_priv(api_keys["leakcheck_apikey"], query)
             if "emailrep" in api_keys and query == "email":
                 current_target.get_emailrepio(api_keys["emailrep"])
             if "hunterio" in api_keys and query == "email":
@@ -284,7 +287,7 @@ def parse_args(args):
         "-sk",
         "--skip-defaults",
         dest="skip_defaults",
-        help="Skips Scylla and HunterIO check. Ideal for local scans",
+        help="Skips Scylla, LeakCheck and HunterIO check. Ideal for local scans",
         action="store_true",
         default=False,
     )


### PR DESCRIPTION
LeakCheck offers a search engine with a database of more than 9 billion leaked records. Users can search for leaked information using email addresses, usernames, phone numbers, keywords, and domain names.

- Website: https://leakcheck.io/
- Docs: https://wiki.leakcheck.io/en/api
- Contact: [the@leakcheck.net](mailto:the@leakcheck.net)