### PR TITLE
test: establish baseline unit and skipping implicitly integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
   * If there is no on-going development branch, there should still be the current version's dev branch
   * If unsure, open an issue and you'll be pointed to the right branch, or a seperate branch can be created for you
 
-* Make sure your code passes the included tests. You can run the 4 unit tests by using `python3 -m unittest` in h8mail's top level directory. To run all 6 tests (including integration tests), use `RUN_INTEGRATION_TESTS=1 python -m unittest tests.test_h8mail`
+* Make sure your code passes the included tests. Run the offline test suite with `python3 -m unittest` in h8mail's top-level directory. To include the opt-in live integration tests, use `RUN_INTEGRATION_TEST=1 python3 -m unittest tests.test_h8mail`.
 
 * Code should be formatted using [Python Black](https://github.com/psf/black). Most IDE's can run `black` directly. You can also launch it [from CLI](https://github.com/psf/black#installation-and-usage)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
   * If there is no on-going development branch, there should still be the current version's dev branch
   * If unsure, open an issue and you'll be pointed to the right branch, or a seperate branch can be created for you
 
-* Make sure your code passes the included tests. You can run them by using `python3 -m unittest` in h8mail's top level directory
+* Make sure your code passes the included tests. You can run the 4 unit tests by using `python3 -m unittest` in h8mail's top level directory. To run all 6 tests (including integration tests), use `RUN_INTEGRATION_TESTS=1 python -m unittest tests.test_h8mail`
 
 * Code should be formatted using [Python Black](https://github.com/psf/black). Most IDE's can run `black` directly. You can also launch it [from CLI](https://github.com/psf/black#installation-and-usage)
 

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -21,62 +21,55 @@ def print_test_banner(testname):
     print("\tTESTING: "+testname)
     print("========================")
     print("========================")
-
-
-def make_temp_directory():
-    emails = """
-    john.smith@gmail.com
-    john.smith@gmail.com
-    fijsdhkfnhqsdkf
-    fdqfqsdff
-    test@evilcorp.com
-    notfound@email.com
-    """
-    creds = """
-    john.smith@gmail.com:SecretPASS
-    bloblfd
-    fjsdkf,ds
-    test@evilcorp.com:An0therSECRETpassw0rd
-    ddqsdqs
-    """
-    temp_dir = tempfile.mkdtemp()
-    try:
-        fd_emails = open(os.path.join(temp_dir, "test-emails.txt"), "w")
-        fd_emails.writelines(emails)
-        fd_emails.close()
-        fd_creds = open(os.path.join(temp_dir, "test-creds.txt"), "w")
-        fd_creds.writelines(creds)
-        fd_creds.close()
-        tar = tarfile.open(os.path.join(temp_dir, "test-creds.tar.gz"), "w:gz")
-        tar.add(os.path.join(temp_dir, "test-creds.txt"))
-        tar.close()
-
-        return temp_dir
-    except Exception as e:
-        print(e)
-
+    
 
 class TestH8mail(unittest.TestCase):
     """Tests for `h8mail` package."""
 
     def setUp(self):
-        """Generating local files"""
-        self.temp_dir = make_temp_directory()
+        """Generating local files with automatic cleanup (Python 3.10+)"""
+        self.temp_dir = tempfile.TemporaryDirectory()
         print("Created Temp Dir: " + self.temp_dir)
         print(os.listdir(self.temp_dir))
 
         print("Registering dir + content for auto cleanup: " + self.temp_dir)
-        self.addCleanup(self.temp_directory.cleanup)
+        self.addCleanup(self.temp_dir.cleanup)
 
-    
-        self.filetargets = os.path.join(self.temp_dir, "test-emails.txt")
-        self.filetxt = os.path.join(self.temp_dir, "test-creds.txt")
-        self.filegz = os.path.join(self.temp_dir, "test-creds.tar.gz")
+        self.temp_path = self.temp_dir.name
+
+        # --- Dummy Data ---
+        emails = """
+        john.smith@gmail.com
+        john.smith@gmail.com
+        fijsdhkfnhqsdkf
+        fdqfqsdff
+        test@evilcorp.com
+        notfound@email.com
+        """
+
+        creds = """
+        john.smith@gmail.com:SecretPASS
+        bloblfd
+        fjsdkf,ds
+        test@evilcorp.com:An0therSECRETpassw0rd
+        ddqsdqs
+        """
+
+
+        self.filetargets = os.path.join(self.temp_path, "test-emails.txt")
+        self.filetxt = os.path.join(self.temp_path, "test-creds.txt")
+        self.filegz = os.path.join(self.temp_path, "test-creds.tar.gz")
+
         print("Test files generated in : " + self.temp_dir)
 
-        # a = open(self.filetxt, "r")
-        # print(a.readlines())
+        with open(self.filetargets, "w", encoding="utf-8") as f:
+            f.write(emails)
 
+        with open(self.filetxt, "w", encoding="utf-8") as f:
+            f.write(creds)
+
+        with tarfile.open(self.filegz, "w:gz") as tar:
+            tar.add(self.filetxt, arcname="test-creds.txt")
 
     def test_000_simple(self):
         """Simple test"""

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -64,6 +64,11 @@ class TestH8mail(unittest.TestCase):
         self.temp_dir = make_temp_directory()
         print("Created Temp Dir: " + self.temp_dir)
         print(os.listdir(self.temp_dir))
+
+        print("Registering dir + content for auto cleanup: " + self.temp_dir)
+        self.addCleanup(self.temp_directory.cleanup)
+
+    
         self.filetargets = os.path.join(self.temp_dir, "test-emails.txt")
         self.filetxt = os.path.join(self.temp_dir, "test-creds.txt")
         self.filegz = os.path.join(self.temp_dir, "test-creds.tar.gz")
@@ -72,10 +77,6 @@ class TestH8mail(unittest.TestCase):
         # a = open(self.filetxt, "r")
         # print(a.readlines())
 
-    def tearDown(self):
-        """Cleaning temp files"""
-        print("Removing dir + content: " + self.temp_dir)
-        self.addCleanup(self.temp_directory.cleanup)
 
     def test_000_simple(self):
         """Simple test"""

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -78,20 +78,13 @@ class TestH8mail(unittest.TestCase):
             
         print(f"Test files generated in : {self.temp_path}")
 
+
     @unittest.skipUnless(
         os.getenv("RUN_INTEGRATION_TEST") == "1",
         "Skipping integration test by default. Set RUN_INTEGRATION_TEST=1 to run."
     )
     def test_000_simple_integration_test(self):
         """Simple integration test"""
-        run.print_banner()
-        print_test_banner("VANILLA")
-
-        user_args = run.parse_args(["-t", "test@example.com"])
-        run.h8mail(user_args)
-
-    def test_000_simple(self):
-        """Simple test"""
         run.print_banner()
         print_test_banner("VANILLA")
 
@@ -116,7 +109,7 @@ class TestH8mail(unittest.TestCase):
         user_args_gz = run.parse_args(["-t", self.filetargets, "-gz", self.filegz, "-sk", "-sf"])
         run.h8mail(user_args_gz)
 
-    def test_003_url(self):
+    def test_005_url(self):
         run.print_banner()
         print_test_banner("URL-RAW")
         user_args_lb = run.parse_args(["-u", "https://raw.githubusercontent.com/khast3x/h8mail/master/tests/test_email.txt"])

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -7,8 +7,7 @@
 import unittest
 import tempfile
 import os
-import tarfile
-import gzip # Unused import, but may be used if write_gzip_file function is uncommented
+import gzip
 from h8mail.utils import run
 from h8mail.utils import classes
 from h8mail.utils import helpers
@@ -33,13 +32,12 @@ class TestH8mail(unittest.TestCase):
             file_handle.write(content)
         return path
     
-    # Uncomment to test gzip writing functionality
-    # def write_gzip_file(self, filename, content):
-    #     """Write content to a gzip file in temp_dir."""
-    #     path = os.path.join(self.temp_path, filename)
-    #     with gzip.open(path, "wt", encoding="utf-8") as file_handle:
-    #         file_handle.write(content)
-    #     return path
+    def write_gzip_file(self, filename, content):
+        """Write content to a gzip file in temp_dir."""
+        path = os.path.join(self.temp_path, filename)
+        with gzip.open(path, "wt", encoding="utf-8") as file_handle:
+            file_handle.write(content)
+        return path
 
     def setUp(self):
         """Generating local files with automatic cleanup (Python 3.10+)"""
@@ -72,9 +70,7 @@ class TestH8mail(unittest.TestCase):
         self.filetargets = self.write_text_file("test-emails.txt", emails)
         self.filetxt = self.write_text_file("test-creds.txt", creds)
                 
-        self.filegz = os.path.join(self.temp_path, "test-creds.tar.gz")
-        with tarfile.open(self.filegz, "w:gz") as tar:
-            tar.add(self.filetxt, arcname="test-creds.txt")
+        self.filegz = self.write_gzip_file("test-creds.txt.gz", creds)
             
         print(f"Test files generated in : {self.temp_path}")
 
@@ -91,25 +87,69 @@ class TestH8mail(unittest.TestCase):
         user_args = run.parse_args(["-t", "test@example.com"])
         run.h8mail(user_args)
 
-    def test_001_local_files_txt_gz(self):
-        """Local file search Test"""
-        run.print_banner()
-        print_test_banner("TXT LOCAL")
-        user_args_lb = run.parse_args(["-t", self.filetargets, "-lb", self.filetxt, "-sk"])
-        run.h8mail(user_args_lb)
-        print_test_banner("TXT LOCAL-SINGLFILE")
-        user_args_lb = run.parse_args(["-t", self.filetargets, "-lb", self.filetxt, "-sk", "-sf"])
-        run.h8mail(user_args_lb)
+    def test_001_cleartext_local_search_returns_exact_matches(self):
+        """Clear-text searches return structured matches without network access."""
+        results = localsearch.local_search_single(
+            [self.filetxt],
+            ["john.smith@gmail.com", "missing@example.com"],
+        )
 
-        run.print_banner()
-        print_test_banner("GZ LOCAL")
-        user_args_gz = run.parse_args(["-t", self.filetargets, "-gz", self.filegz, "-sk"])
-        run.h8mail(user_args_gz)
-        print_test_banner("GZ LOCAL-SINGLEFILE")
-        user_args_gz = run.parse_args(["-t", self.filetargets, "-gz", self.filegz, "-sk", "-sf"])
-        run.h8mail(user_args_gz)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].target, "john.smith@gmail.com")
+        self.assertEqual(results[0].filepath, self.filetxt)
+        self.assertEqual(results[0].line, 1)
+        self.assertEqual(
+            results[0].content.strip(),
+            "john.smith@gmail.com:SecretPASS",
+        )
 
-    def test_002_parse_args_accepts_local_search_options(self) -> None:
+    def test_002_gzip_local_search_returns_exact_matches(self):
+        """Gzip searches return structured matches without network access."""
+        results = localgzipsearch.local_search_single_gzip(
+            [self.filegz],
+            ["test@evilcorp.com", "missing@example.com"],
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].target, "test@evilcorp.com")
+        self.assertEqual(results[0].filepath, self.filegz)
+        self.assertEqual(results[0].line, 4)
+        self.assertEqual(
+            results[0].content.strip(),
+            "test@evilcorp.com:An0therSECRETpassw0rd",
+        )
+
+    def test_003_local_results_are_added_to_matching_targets_only(self):
+        """Local results preserve their source and update only matching targets."""
+        matched = classes.target("john.smith@gmail.com")
+        unmatched = classes.target("missing@example.com")
+        local_result = classes.local_breach_target(
+            "john.smith@gmail.com",
+            self.filetxt,
+            1,
+            "john.smith@gmail.com:SecretPASS\n",
+        )
+        user_args = run.parse_args(["-t", "john.smith@gmail.com", "-sk"])
+
+        results = localsearch.local_to_targets(
+            [matched, unmatched],
+            [local_result],
+            user_args,
+        )
+
+        self.assertIs(results[0], matched)
+        self.assertEqual(matched.pwned, 1)
+        self.assertEqual(unmatched.pwned, 0)
+        self.assertEqual(
+            matched.data[-1],
+            (
+                "LOCALSEARCH",
+                "[test-creds.txt] Line 1: john.smith@gmail.com:SecretPASS",
+                "john.smith@gmail.com:SecretPASS",
+            ),
+        )
+
+    def test_004_parse_args_accepts_local_search_options(self) -> None:
         """Verify CLI argument parser correctly assigns local search flags."""
         arguments = run.parse_args(
             [
@@ -135,7 +175,7 @@ class TestH8mail(unittest.TestCase):
         self.assertTrue(arguments.single_file)
         self.assertIsNone(arguments.user_urls)
 
-    def test_003_parse_args_uses_safe_expected_defaults(self):
+    def test_005_parse_args_uses_safe_expected_defaults(self):
         """Verify CLI argument parser defaults to safe, expected values when given only a target."""
         arguments = run.parse_args(["-t", "john.smith@gmail.com"])
         self.assertFalse(arguments.skip_defaults)
@@ -145,7 +185,7 @@ class TestH8mail(unittest.TestCase):
         self.assertIsNone(arguments.output_file)
         self.assertIsNone(arguments.output_json)
 
-    def test_004_parse_args_accepts_single_target(self) -> None:
+    def test_006_parse_args_accepts_single_target(self) -> None:
         """Verify CLI argument parser correctly assigns a single email target."""
         arguments = run.parse_args(["-t", "john.smith@gmail.com"])
 
@@ -157,7 +197,7 @@ class TestH8mail(unittest.TestCase):
         os.getenv("RUN_INTEGRATION_TEST") == "1",
         "Skipping integration test by default. Set RUN_INTEGRATION_TEST=1 to run.",
     )
-    def test_005_url(self):
+    def test_007_url(self):
         """Fetch targets from a live URL."""
         run.print_banner()
         print_test_banner("URL-RAW")

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -29,13 +29,12 @@ class TestH8mail(unittest.TestCase):
     def setUp(self):
         """Generating local files with automatic cleanup (Python 3.10+)"""
         self.temp_dir = tempfile.TemporaryDirectory()
-        print("Created Temp Dir: " + self.temp_dir)
-        print(os.listdir(self.temp_dir))
-
-        print("Registering dir + content for auto cleanup: " + self.temp_dir)
+        self.temp_path = self.temp_dir.name
+        print(f"Created Temp Dir: {self.temp_path}")
+        print(f"Registering dir + content for auto cleanup: {self.temp_path}")
+        
         self.addCleanup(self.temp_dir.cleanup)
 
-        self.temp_path = self.temp_dir.name
 
         # --- Dummy Data ---
         emails = """

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -5,15 +5,11 @@
 
 
 import unittest
-import sys
-import time
 import tempfile
 import shutil
-import contextlib
 import os
 import tarfile
 import gzip
-import argparse
 from h8mail.utils import run
 from h8mail.utils import classes
 from h8mail.utils import helpers

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -6,7 +6,6 @@
 
 import unittest
 import tempfile
-import shutil
 import os
 import tarfile
 import gzip
@@ -76,7 +75,7 @@ class TestH8mail(unittest.TestCase):
     def tearDown(self):
         """Cleaning temp files"""
         print("Removing dir + content: " + self.temp_dir)
-        shutil.rmtree(self.temp_dir)
+        self.addCleanup(self.temp_directory.cleanup)
 
     def test_000_simple(self):
         """Simple test"""

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -26,6 +26,21 @@ def print_test_banner(testname):
 class TestH8mail(unittest.TestCase):
     """Tests for `h8mail` package."""
 
+    def write_text_file(self, filename, content):
+        """Write content to a text file in temp_dir."""
+        path = os.path.join(self.temp_path, filename)
+        with open(path, "w", encoding="utf-8") as file_handle:
+            file_handle.write(content)
+        return path
+    
+    # Uncomment to test gzip writing functionality
+    # def write_gzip_file(self, filename, content):
+    #     """Write content to a gzip file in temp_dir."""
+    #     path = os.path.join(self.temp_path, filename)
+    #     with gzip.open(path, "wt", encoding="utf-8") as file_handle:
+    #         file_handle.write(content)
+    #     return path
+
     def setUp(self):
         """Generating local files with automatic cleanup (Python 3.10+)"""
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -54,21 +69,14 @@ class TestH8mail(unittest.TestCase):
         ddqsdqs
         """
 
-
-        self.filetargets = os.path.join(self.temp_path, "test-emails.txt")
-        self.filetxt = os.path.join(self.temp_path, "test-creds.txt")
+        self.filetargets = self.write_text_file("test-emails.txt", emails)
+        self.filetxt = self.write_text_file("test-creds.txt", creds)
+                
         self.filegz = os.path.join(self.temp_path, "test-creds.tar.gz")
-
-        print(f"Test files generated in : {self.temp_path}")
-
-        with open(self.filetargets, "w", encoding="utf-8") as f:
-            f.write(emails)
-
-        with open(self.filetxt, "w", encoding="utf-8") as f:
-            f.write(creds)
-
         with tarfile.open(self.filegz, "w:gz") as tar:
             tar.add(self.filetxt, arcname="test-creds.txt")
+            
+        print(f"Test files generated in : {self.temp_path}")
 
     def test_000_simple(self):
         """Simple test"""

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -145,6 +145,14 @@ class TestH8mail(unittest.TestCase):
         self.assertIsNone(arguments.output_file)
         self.assertIsNone(arguments.output_json)
 
+    def test_004_parse_args_accepts_single_target(self) -> None:
+        """Verify CLI argument parser correctly assigns a single email target."""
+        arguments = run.parse_args(["-t", "john.smith@gmail.com"])
+
+        self.assertEqual(arguments.user_targets, ["john.smith@gmail.com"])
+        self.assertIsNone(arguments.local_breach_src)
+        self.assertIsNone(arguments.user_urls)
+
     def test_005_url(self):
         run.print_banner()
         print_test_banner("URL-RAW")

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -153,7 +153,12 @@ class TestH8mail(unittest.TestCase):
         self.assertIsNone(arguments.local_breach_src)
         self.assertIsNone(arguments.user_urls)
 
+    @unittest.skipUnless(
+        os.getenv("RUN_INTEGRATION_TEST") == "1",
+        "Skipping integration test by default. Set RUN_INTEGRATION_TEST=1 to run.",
+    )
     def test_005_url(self):
+        """Fetch targets from a live URL."""
         run.print_banner()
         print_test_banner("URL-RAW")
         user_args_lb = run.parse_args(["-u", "https://raw.githubusercontent.com/khast3x/h8mail/master/tests/test_email.txt"])

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -54,7 +54,7 @@ class TestH8mail(unittest.TestCase):
         # --- Dummy Data ---
         emails = """
         john.smith@gmail.com
-        john.smith@gmail.com
+        test@example.com
         fijsdhkfnhqsdkf
         fdqfqsdff
         test@evilcorp.com

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -135,6 +135,16 @@ class TestH8mail(unittest.TestCase):
         self.assertTrue(arguments.single_file)
         self.assertIsNone(arguments.user_urls)
 
+    def test_003_parse_args_uses_safe_expected_defaults(self):
+        """Verify CLI argument parser defaults to safe, expected values when given only a target."""
+        arguments = run.parse_args(["-t", "john.smith@gmail.com"])
+        self.assertFalse(arguments.skip_defaults)
+        self.assertFalse(arguments.single_file)
+        self.assertFalse(arguments.loose)
+        self.assertFalse(arguments.debug)
+        self.assertIsNone(arguments.output_file)
+        self.assertIsNone(arguments.output_json)
+
     def test_005_url(self):
         run.print_banner()
         print_test_banner("URL-RAW")

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -8,7 +8,7 @@ import unittest
 import tempfile
 import os
 import tarfile
-import gzip
+import gzip # Unused import, but may be used if write_gzip_file function is uncommented
 from h8mail.utils import run
 from h8mail.utils import classes
 from h8mail.utils import helpers
@@ -77,6 +77,18 @@ class TestH8mail(unittest.TestCase):
             tar.add(self.filetxt, arcname="test-creds.txt")
             
         print(f"Test files generated in : {self.temp_path}")
+
+    @unittest.skipUnless(
+        os.getenv("RUN_INTEGRATION_TEST") == "1",
+        "Skipping integration test by default. Set RUN_INTEGRATION_TEST=1 to run."
+    )
+    def test_000_simple_integration_test(self):
+        """Simple integration test"""
+        run.print_banner()
+        print_test_banner("VANILLA")
+
+        user_args = run.parse_args(["-t", "test@example.com"])
+        run.h8mail(user_args)
 
     def test_000_simple(self):
         """Simple test"""

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -59,7 +59,7 @@ class TestH8mail(unittest.TestCase):
         self.filetxt = os.path.join(self.temp_path, "test-creds.txt")
         self.filegz = os.path.join(self.temp_path, "test-creds.tar.gz")
 
-        print("Test files generated in : " + self.temp_dir)
+        print(f"Test files generated in : {self.temp_path}")
 
         with open(self.filetargets, "w", encoding="utf-8") as f:
             f.write(emails)

--- a/tests/test_h8mail.py
+++ b/tests/test_h8mail.py
@@ -91,7 +91,7 @@ class TestH8mail(unittest.TestCase):
         user_args = run.parse_args(["-t", "test@example.com"])
         run.h8mail(user_args)
 
-    def test_002_local_files_txt_gz(self):
+    def test_001_local_files_txt_gz(self):
         """Local file search Test"""
         run.print_banner()
         print_test_banner("TXT LOCAL")
@@ -108,6 +108,32 @@ class TestH8mail(unittest.TestCase):
         print_test_banner("GZ LOCAL-SINGLEFILE")
         user_args_gz = run.parse_args(["-t", self.filetargets, "-gz", self.filegz, "-sk", "-sf"])
         run.h8mail(user_args_gz)
+
+    def test_002_parse_args_accepts_local_search_options(self) -> None:
+        """Verify CLI argument parser correctly assigns local search flags."""
+        arguments = run.parse_args(
+            [
+                "-t",
+                "john.smith@gmail.com",
+                "test@example.com",
+                "-lb",
+                "/tmp/synthetic-breach.txt",
+                "-sk",
+                "-sf",
+            ]
+        )
+
+        self.assertEqual(
+            arguments.user_targets,
+            ["john.smith@gmail.com", "test@example.com"],
+        )
+        self.assertEqual(
+            arguments.local_breach_src,
+            ["/tmp/synthetic-breach.txt"],
+        )
+        self.assertTrue(arguments.skip_defaults)
+        self.assertTrue(arguments.single_file)
+        self.assertIsNone(arguments.user_urls)
 
     def test_005_url(self):
         run.print_banner()


### PR DESCRIPTION
## Summary

- Refactor test fixture creation and cleanup
- Add baseline CLI argument-parsing tests
- Separate network-dependent integration tests from offline unit tests
- Make integration tests opt-in with RUN_INTEGRATION_TEST=1

## Validation
### Unit tests
python3 -m unittest

### Unit tests + integration tests
RUN_INTEGRATION_TEST=1 python -m unittest tests.test_h8mail

Related Issue: https://github.com/khast3x/h8mail/issues/186
test: establish baseline unit and skip integration tests implicitly